### PR TITLE
Improve compat file to accept `unknown` causes

### DIFF
--- a/lib/error-with-cause-compat.d.ts
+++ b/lib/error-with-cause-compat.d.ts
@@ -1,6 +1,6 @@
 export class ErrorWithCause extends Error {
     constructor(message: string, { cause }?: {
-        cause?: Error;
+        cause?: unknown;
     } | undefined);
     // We need to be stricter here because of esnext lib in TS 4.6 and TS 4.7
     cause?: Error;


### PR DESCRIPTION
There's no issue with that, only with the `.cause` property